### PR TITLE
Implement callouts

### DIFF
--- a/source/assets/css/callout.css
+++ b/source/assets/css/callout.css
@@ -1,0 +1,33 @@
+.callout {
+  border-radius: 0.25rem;
+  padding: 1px 0.25rem;
+}
+
+.callout--plain {
+  background-color: #fe8;
+  color: #000;
+}
+
+.callout--avoid {
+  text-decoration: line-through;
+  color: #c00;
+}
+
+.callout--prefer {
+  color: #0a0;
+}
+
+.callout--pink {
+  background-color: #fac;
+  color: #000;
+}
+
+.callout--blue {
+  background-color: #8cf;
+  color: #000;
+}
+
+.callout--green {
+  background-color: #afc;
+  color: #000;
+}

--- a/source/assets/js/callout.js
+++ b/source/assets/js/callout.js
@@ -1,0 +1,109 @@
+(() => {
+  const application = Stimulus.Application.start()
+
+  application.register("callout", class extends Stimulus.Controller {
+    static get values() {
+      return { text: String, type: String }
+    }
+
+    initialize() {
+      for (const range of this.calloutRanges) {
+        const content = range.toString()
+        const element = this.createCalloutElement(content)
+        range.deleteContents()
+        range.insertNode(element)
+      }
+    }
+
+    connect() {
+      this.element.parentElement.removeChild(this.element)
+    }
+
+    get calloutRanges() {
+      return this.matches.map(([start, end]) => {
+        return this.createCalloutRange(start, end)
+      })
+    }
+
+    createCalloutElement(textContent) {
+      const element = document.createElement("span")
+      element.textContent = textContent
+      element.className = this.className
+      return element
+    }
+
+    createCalloutRange(start, end) {
+      const range = document.createRange()
+      let startPosition = 0
+
+      for (const node of this.textNodes) {
+        const endPosition = startPosition + node.textContent.length
+
+        if (startPosition <= start && start <= endPosition) {
+          range.setStart(node, start - startPosition)
+        }
+
+        if (startPosition <= end && end <= endPosition) {
+          range.setEnd(node, end - startPosition)
+        }
+
+        startPosition = endPosition
+      }
+
+      return range
+    }
+
+    get textNodes() {
+      const nodes = []
+      const iterator = this.createTextNodeIterator()
+      while (iterator.nextNode()) nodes.push(iterator.currentNode)
+      return nodes
+    }
+
+    get matches() {
+      const matches = []
+      let match, position
+      while (match = this.findNextMatch(position)) matches.push(match), position = match[0]
+      return matches
+    }
+
+    createTextNodeIterator() {
+      return document.createTreeWalker(this.contentElement, NodeFilter.SHOW_TEXT)
+    }
+
+    findNextMatch(fromPosition = -1) {
+      const position = this.content.indexOf(this.textValue, fromPosition + 1)
+      return position == -1 ? null : [position, position + this.textValue.length]
+    }
+
+    get contentElement() {
+      const element = this.createContentElementIterator().nextNode()
+      if (!element) throw new Error("can't find content element")
+      return element
+    }
+
+    createContentElementIterator() {
+      return document.createTreeWalker(this.parentElement.parentElement, NodeFilter.SHOW_ELEMENT, (node) => {
+        const follows = this.element.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING
+        const isContent = this.isContentElement(node)
+        return follows && isContent ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+      })
+    }
+
+    isContentElement(element) {
+      return element.tagName.toLowerCase() == "pre"
+    }
+
+    get content() {
+      return this.contentElement.textContent
+    }
+
+    get className() {
+      return "callout " + (this.hasTypeValue ? "callout--" + this.typeValue : "callout--plain")
+    }
+
+    get parentElement() {
+      return this.element.parentElement
+    }
+  })
+})()

--- a/source/layouts/default.html.erb
+++ b/source/layouts/default.html.erb
@@ -13,6 +13,7 @@
   <%= stylesheet_link_tag "assets/css/syntax.css" %>
   <%= stylesheet_link_tag "assets/css/lanyon.css" %>
   <%= stylesheet_link_tag "assets/css/styles.css" %>
+  <%= stylesheet_link_tag "assets/css/callout.css" %>
 
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
 
@@ -20,6 +21,8 @@
   <link rel="shortcut icon" href="">
 
   <link rel="alternate" type="application/rss+xml" title="RSS" href="">
+  <script src="https://unpkg.com/stimulus/dist/stimulus.umd.js"></script>
+  <%= javascript_include_tag "assets/js/callout.js" %>
 </head>
 
 <body>

--- a/source/posts/2021-04-02-how-basecamp-uses-hotwire-part-1-hey-loads-frames-on-click.html.md
+++ b/source/posts/2021-04-02-how-basecamp-uses-hotwire-part-1-hey-loads-frames-on-click.html.md
@@ -12,482 +12,56 @@ How Basecamp uses Hotwire: Load frames on click
 I reverse engineer Hey so you don't have to
 Dont even use rails
 
+<!-- Blank space between meta tag and code block is necessary -->
+<meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/highlight-me&quot;">
 
 ```html
-<details data-controller="popup-menu bridge--menu popup-picker"
-         data-action="toggle->popup-picker#cancelOnClose
-                     toggle->popup-menu#update
-                     focusin@window->popup-menu#closeOnFocusOutside
-                     click@window->popup-menu#closeOnClickOutside
-                     reset->popup-menu#closeAndRestoreFocus"
-         data-popup-picker-filtering-class="popup-picker--filtering"
-         data-popup-picker-adding-class="popup-picker--adding">
-  <summary class="navbar__item navbar__logo navbar__logo--open
-                  colorize-after-purple btn--focusable"
-            data-controller="hotkey"
-            data-action="click->bridge--menu#show
-                         toggle->popup-menu#update"
-            aria-haspopup="menu"
-            aria-label="Go to"
-            data-hotkey="h,Meta+j">
-    <a data-turbo-frame="my_navigation"
-        data-popup-menu-target="link"
-        href="/my/navigation"
-        hidden="">
-        HEY
-    </a>
-  </summary>
-
-  <turbo-frame id="my_navigation"
-               target="_top"
-               role="menu"
-               class="popup-menu popup-menu--padded popup-menu--centered
-                      popup-menu--tall navbar__menu navbar__menu--hey">
-    <span class="u-for-screen-reader" role="menuitem" aria-disabled="true">
-      Loading
-    </span>
-  </turbo-frame>
-</details>
+<div data-controller="loader"
+     data-loader-url-value="/highlight-me">
+</div>
 ```
 
-```scss
-@import 'variables';
+<!-- Consecutive meta tags can target consecutive statements -->
+<meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/avoid-this&quot;&gt;" data-callout-type-value="avoid">
+<meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/prefer-this&quot;&gt;" data-callout-type-value="prefer">
 
-*,
-*:after,
-*:before {
-  box-sizing: border-box;
-}
-
-[tabindex='-1']:focus {
-  outline: none !important;
-}
-
-:root {
-  --spectrum-slider-handle-background-color: #fff;
-  --spectrum-slider-handle-background-color-down: #fff;
-  --spectrum-slider-handle-border-color: #{$text-color-light};
-  --spectrum-slider-handle-border-color-hover: #{$oc-blue-4};
-  --spectrum-slider-handle-border-color-down: #{$oc-blue-4};
-  --spectrum-label-text-line-height: 200%;
-}
-
-#commento {
-  .loading {
-    font-size: 1rem;
-    text-align: center;
-    color: $text-color-light;
-    font-family: $font-family-sans-serif;
-  }
-
-  &:has(> #commento-footer) .loading {
-    display: none;
-  }
-}
-
-.comments .commento-root {
-  font-family: $font-family-sans-serif;
-  margin-top: -1rem;
-
-  textarea,
-  .commento-card .commento-body p {
-    font-family: $font-family-serif;
-  }
-
-  .commento-anonymous-checkbox-container input[type='checkbox'] + label {
-    font-weight: normal;
-    text-transform: none;
-    font-size: 14px;
-
-    &::before {
-      margin-top: 4px;
-    }
-
-    &::after {
-      margin-top: 2px;
-    }
-  }
-
-  a {
-    color: $link-color;
-    transition: color 150ms ease;
-
-    &:hover {
-      color: $link-color-hover;
-    }
-  }
-
-  .commento-submit-button {
-    background-color: $link-color;
-    transition: background-color 150ms ease;
-    box-shadow: none;
-    margin-right: 0;
-
-    &:hover {
-      background-color: $link-color-hover;
-    }
-  }
-
-  .commento-markdown-button {
-    margin-left: 2px;
-  }
-
-  .commento-login .commento-login-text {
-    margin-right: 2px;
-    font-weight: normal;
-  }
-
-  textarea {
-    padding: 1rem;
-    &::placeholder {
-      font-size: 1rem;
-    }
-  }
-
-  .commento-card {
-    margin-top: 2rem;
-  }
-
-  .commento-footer {
-    display: none;
-  }
-}
-
-pre {
-  counter-reset: line-numbering;
-  border: solid 1px #d9d9d9;
-  border-radius: 0;
-  background: #fff;
-  padding: 0;
-  line-height: 23px;
-  margin-bottom: 30px;
-  white-space: pre;
-  overflow-x: auto;
-  word-break: inherit;
-  word-wrap: inherit;
-}
-
-pre a::before {
-  content: counter(line-numbering);
-  counter-increment: line-numbering;
-  padding-right: 1em; /* space after numbers */
-  width: 25px;
-  text-align: right;
-  opacity: 0.7;
-  display: inline-block;
-  color: #aaa;
-  background: #eee;
-  margin-right: 16px;
-  padding: 2px 10px;
-  font-size: 13px;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-pre a:first-of-type::before {
-  padding-top: 10px;
-}
-
-pre a:last-of-type::before {
-  padding-bottom: 10px;
-}
-
-pre a:only-of-type::before {
-  padding: 10px;
-}
-
-.class-name {
-  padding: 1px;
-
-  span {
-    padding: 1px;
-  }
-
-  .nested-class {
-    padding: 1px;
-  }
-}
+```html
+<div data-controller="loader"
+     data-loader-url-value="/avoid-this">
+     data-loader-url-value="/prefer-this">
+</div>
 ```
 
-```javascript
-// popup_menu_controller.js
-import { addToTabOrder, cancel, delay, nextFrame, removeFromTabOrder, wrapAroundAccess } from "helpers"
+<!-- Notice how meta tags only affect blocks that immidiately follow them,
+     the next block has no styling -->
 
-export default class extends ApplicationController {
-  static targets = [ "item", "link", "input" ]
-  static values = { lockOnSelection: Boolean }
-
-  initialize() {
-    if (this.hasLinkTarget) this.linkTarget.hidden = true
-    this.observeMutations(this.removeTabstops, { childList: true })
-  }
-
-  connect() {
-    this.summaryElement?.setAttribute("aria-haspopup", "menu")
-    this.update()
-  }
-
-  disconnect() {
-    this.close()
-  }
-
-  // Actions
-
-  async update() {
-    if (!this.element.open) {
-      return
-    }
-
-    if (this.hasLinkTarget) {
-      this.linkTarget.click()
-    }
-
-    if (this.frameElement) {
-      if (this.frameElement.disabled) {
-        this.close()
-        return
-      }
-
-      await this.frameElement.loaded
-    }
-
-    await Promise.all(loadFrameElementsWithin(this.element))
-    this.summaryElement?.setAttribute("aria-expanded", this.element.open)
-    this.focusInitial()
-    this.removeTabstops()
-  }
-
-  navigate(event) {
-    switch (event.key) {
-      case "ArrowUp":
-        if (this.element.open && isActive(this.summaryElement)) {
-          this.summaryElement.click()
-          cancel(event)
-        } else {
-          this.focusPrevious()
-          cancel(event)
-        }
-        break
-      case "ArrowLeft":
-        if (isInput(event.target)) break
-        cancel(event)
-        this.focusPrevious()
-        break
-      case "ArrowDown":
-        if (!this.element.open && isActive(this.summaryElement)) {
-          this.summaryElement.click()
-          cancel(event)
-        } else {
-          this.focusNext()
-          cancel(event)
-        }
-        break
-      case "ArrowRight":
-        if (isInput(event.target)) break
-        cancel(event)
-        this.focusNext()
-        break
-      case "Escape":
-        cancel(event)
-        this.closeAndRestoreFocus()
-        break
-      case "Enter":
-        if (!(this.activeItem || isActive(this.summaryElement))) this.activateInitial()
-        break
-      case "Control":
-        cancel(event)
-        if (this.hasInputTarget) { this.inputTarget.blur() }
-        break
-    }
-  }
-
-  closeOnClickOutside({ target }) {
-    if (this.element.contains(target)) return
-    if (this.forceMenuOpen) return
-
-    this.close()
-  }
-
-  closeOnFocusOutside({ target }) {
-    if (!this.element.open) return
-    if (this.element.contains(target)) return
-    if (target.matches("main")) return
-    if (this.forceMenuOpen) return
-
-    this.close()
-  }
-
-  closeAndRestoreFocus() {
-    this.close()
-    this.summaryElement.focus()
-  }
-
-  toggleSummaryTabstop() {
-    const summary = this.element.querySelector("summary")
-
-    this.element.open ? removeFromTabOrder(summary) : addToTabOrder(summary)
-  }
-
-  async willFocusByMouse() {
-    this.focusingByMouse = true
-    await delay()
-    this.focusingByMouse = false
-  }
-
-  displayMenu() {
-    if (this.focusingByMouse) return
-    this.element.open = true
-  }
-
-  close() {
-    this.element.open = false
-  }
-
-  // Private
-  //
-
-  removeTabstops() {
-    this.itemTargets.forEach(target => target.setAttribute("tabindex", "-1"))
-  }
-
-  async activateInitial() {
-    await this.focusInitial()
-    await nextFrame()
-    this.initialItem?.click()
-  }
-
-  async focusInitial() {
-    await nextFrame()
-
-    if (this.hasInputTarget) {
-      this.focusExclusively(this.inputTarget)
-    } else if (this.hasItems) {
-      this.focusExclusively(this.initialItem)
-    }
-  }
-
-  async focusPrevious() {
-    await nextFrame()
-    this.focusExclusively(this.getItemInDirection(-1))
-  }
-
-  async focusNext() {
-    await nextFrame()
-    this.focusExclusively(this.getItemInDirection(+1))
-  }
-
-  getItemInDirection(direction) {
-    const index = this.items.indexOf(document.activeElement) + direction
-
-    return wrapAroundAccess(this.items, index)
-  }
-
-  get forceMenuOpen() {
-    return this.lockOnSelectionValue && (
-      this.element.querySelector(":checked") ||
-      this.element.contains(document.activeElement)
-    )
-  }
-
-  focusExclusively(element) {
-    if (element) {
-      this.removeTabstops()
-      element.removeAttribute("tabindex")
-      element.focus()
-    }
-  }
-
-  get items() {
-    return this.itemTargets.filter(isVisible)
-  }
-
-  get hasItems() {
-    return this.itemTargets.some(isVisible)
-  }
-
-  get activeItem() {
-    return this.itemTargets.find(isActive)
-  }
-
-  get initialItem() {
-    return this.items[0]
-  }
-
-  get summaryElement() {
-    return this.element.querySelector("summary")
-  }
-
-  get frameElement() {
-    const id = this.hasLinkTarget && this.linkTarget.getAttribute("data-turbo-frame")
-    return id && document.getElementById(id)
-  }
-}
-
-function loadFrameElementsWithin(element) {
-  const frames = [ ...element.querySelectorAll("turbo-frame[src]:not([disabled])") ]
-
-  return frames.map(frame => frame.loaded)
-}
-
-function isInput(element) {
-  return element.tagName == "INPUT"
-}
-
-function isActive(element) {
-  return element == document.activeElement
-}
-
-function isVisible(element) {
-  return element.offsetParent != null
-}
+```html
+<div data-controller="loader"
+     data-loader-url-value="/messages">
+</div>
 ```
 
-```javascript
-// popup_picker_controller.js
-import { cancel, isMobile, resetInput } from "helpers"
+<!-- Other color options, in case you need them: -->
+<meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/messages&quot;" data-callout-type-value="pink">
 
-export default class extends ApplicationController {
-  static targets = [ "input" ]
-  static classes = [ "filtering", "adding" ]
+```html
+<div data-controller="loader"
+     data-loader-url-value="/messages">
+</div>
+```
 
-  // Actions
+<meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/messages&quot;" data-callout-type-value="blue">
 
-  filtering({ target }) {
-    this.classList.toggle(this.filteringClass, target.value)
-  }
+```html
+<div data-controller="loader"
+     data-loader-url-value="/messages">
+</div>
+```
 
-  adding({ target }) {
-    this.classList.toggle(this.addingClass, target.value)
-  }
+<meta data-controller="callout" data-callout-text-value="data-loader-url-value=&quot;/messages&quot;" data-callout-type-value="green">
 
-  cancel() {
-    this.reset()
-    this.inputTarget.focus()
-  }
-
-  cancelOnClose() {
-    if (!this.element.open && !isMobile) this.reset()
-  }
-
-  resetAndRestoreFocus(event) {
-    const [ firstInput ] = this.inputTargets
-
-    if (firstInput !== document.activeElement) {
-      cancel(event)
-      this.reset()
-      firstInput.focus()
-    }
-  }
-
-  // Private
-
-  reset() {
-    this.inputTargets.forEach(resetInput)
-    this.classList.remove(this.filteringClass, this.addingClass)
-  }
-}
+```html
+<div data-controller="loader"
+     data-loader-url-value="/messages">
+</div>
 ```


### PR DESCRIPTION
Very much based on stimulus docs and the boringrails.com implementation of that same pattern.

### What changed:
We can now highlight (or –callout–) bits of code within a code block.

### Instructions:
![callout instructions](https://user-images.githubusercontent.com/31393016/114286100-7a37af00-9a21-11eb-8dc4-2d9aa6cfcc6f.png)[[

### Result:
![callout result](https://user-images.githubusercontent.com/31393016/114286110-86bc0780-9a21-11eb-8ccc-8717658eeebf.png)

### To-do
redcarpet seems to be rendering empty p tags where the meta tags would be. It would probably be more semantically correct to not render anything.